### PR TITLE
Added standard exceptions

### DIFF
--- a/bazooka/exceptions.py
+++ b/bazooka/exceptions.py
@@ -48,11 +48,23 @@ class ConflictError(ClientError):
     pass
 
 
+class BadRequestError(ClientError):
+    pass
+
+
+class ForbiddenError(ClientError):
+    pass
+
+
 def wrap_to_bazooka_exception(cause):
     if isinstance(cause, exceptions.HTTPError):
         if httplib.NOT_FOUND == cause.response.status_code:
             raise NotFoundError(cause)
         elif httplib.CONFLICT == cause.response.status_code:
             raise ConflictError(cause)
+        elif httplib.BAD_REQUEST == cause.response.status_code:
+            raise BadRequestError(cause)
+        elif httplib.FORBIDDEN == cause.response.status_code:
+            raise ForbiddenError(cause)
         raise BaseHTTPException(cause)
     raise cause


### PR DESCRIPTION
**Changes:**
- Added new exception classes `BadRequestError` and `ForbiddenError` inheriting from `ClientError`
- Updated `wrap_to_bazooka_exception` handler to:
  - Raise `BadRequestError` when HTTP 400 (BAD_REQUEST) status is encountered
  - Raise `ForbiddenError` when HTTP 403 (FORBIDDEN) status is encountered