### PR TITLE
Introduce dedicated exception for unauthorized HTTP responses

### DIFF
--- a/bazooka/exceptions.py
+++ b/bazooka/exceptions.py
@@ -56,10 +56,16 @@ class ForbiddenError(ClientError):
     pass
 
 
+class UnauthorizedError(ClientError):
+    pass
+
+
 def wrap_to_bazooka_exception(cause):
     if isinstance(cause, exceptions.HTTPError):
         if httplib.NOT_FOUND == cause.response.status_code:
             raise NotFoundError(cause)
+        elif httplib.UNAUTHORIZED == cause.response.status_code:
+            raise UnauthorizedError(cause)
         elif httplib.CONFLICT == cause.response.status_code:
             raise ConflictError(cause)
         elif httplib.BAD_REQUEST == cause.response.status_code:


### PR DESCRIPTION
Added `UnauthorizedError` class inheriting from `ClientError` to represent HTTP 401 errors. Updated `wrap_to_bazooka_exception` handler to map `HTTPError` with status code 401 to the new exception type, providing clearer error differentiation for authentication/authorization failures in downstream error handling.