### PR TITLE
feat: add context-scoped request ID and X-Request-ID header injection

### DIFF
--- a/bazooka/__init__.py
+++ b/bazooka/__init__.py
@@ -22,6 +22,16 @@ from bazooka.api import post
 from bazooka.api import put
 from bazooka.api import request
 from bazooka.client import Client
+from bazooka import request_id
 
 
-__all__ = ["request", "get", "post", "put", "delete", "patch", "Client"]
+__all__ = [
+    "request",
+    "get",
+    "post",
+    "put",
+    "delete",
+    "patch",
+    "Client",
+    "request_id",
+]

--- a/bazooka/request_id.py
+++ b/bazooka/request_id.py
@@ -1,0 +1,21 @@
+import contextvars
+from typing import Optional
+
+REQUEST_ID_HEADER = "X-Request-ID"
+
+_request_id_ctx: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "bazooka_request_id",
+    default=None,
+)
+
+
+def get_request_id() -> Optional[str]:
+    return _request_id_ctx.get()
+
+
+def set_request_id(request_id: Optional[str]):
+    return _request_id_ctx.set(request_id)
+
+
+def reset_request_id(token) -> None:
+    _request_id_ctx.reset(token)

--- a/bazooka/request_id.py
+++ b/bazooka/request_id.py
@@ -13,9 +13,9 @@ def get_request_id() -> Optional[str]:
     return _request_id_ctx.get()
 
 
-def set_request_id(request_id: Optional[str]):
+def set_request_id(request_id: Optional[str]) -> contextvars.Token:
     return _request_id_ctx.set(request_id)
 
 
-def reset_request_id(token) -> None:
+def reset_request_id(token: contextvars.Token) -> None:
     _request_id_ctx.reset(token)

--- a/bazooka/request_id.py
+++ b/bazooka/request_id.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import contextvars
 from typing import Optional
 import uuid
@@ -22,9 +24,11 @@ def resolve_request_id(request_id: Optional[str] = None) -> str:
     return request_id or generate_request_id()
 
 
-def set_request_id(request_id: Optional[str]):
+def set_request_id(
+    request_id: Optional[str] = None,
+) -> contextvars.Token[Optional[str]]:
     return _request_id_ctx.set(resolve_request_id(request_id))
 
 
-def reset_request_id(token) -> None:
+def reset_request_id(token: contextvars.Token[Optional[str]]) -> None:
     _request_id_ctx.reset(token)

--- a/bazooka/request_id.py
+++ b/bazooka/request_id.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 REQUEST_ID_HEADER = "X-Request-ID"
 
-_request_id_ctx: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+_request_id_ctx: "contextvars.ContextVar[Optional[str]]" = contextvars.ContextVar(
     "bazooka_request_id",
     default=None,
 )

--- a/bazooka/request_id.py
+++ b/bazooka/request_id.py
@@ -1,9 +1,10 @@
 import contextvars
 from typing import Optional
+import uuid
 
 REQUEST_ID_HEADER = "X-Request-ID"
 
-_request_id_ctx: "contextvars.ContextVar[Optional[str]]" = contextvars.ContextVar(
+_request_id_ctx: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
     "bazooka_request_id",
     default=None,
 )
@@ -13,9 +14,17 @@ def get_request_id() -> Optional[str]:
     return _request_id_ctx.get()
 
 
-def set_request_id(request_id: Optional[str]) -> contextvars.Token:
-    return _request_id_ctx.set(request_id)
+def generate_request_id() -> str:
+    return str(uuid.uuid4())
 
 
-def reset_request_id(token: contextvars.Token) -> None:
+def resolve_request_id(request_id: Optional[str] = None) -> str:
+    return request_id or generate_request_id()
+
+
+def set_request_id(request_id: Optional[str]):
+    return _request_id_ctx.set(resolve_request_id(request_id))
+
+
+def reset_request_id(token) -> None:
     _request_id_ctx.reset(token)

--- a/bazooka/sessions.py
+++ b/bazooka/sessions.py
@@ -22,6 +22,7 @@ from requests import exceptions
 from requests import sessions
 
 from bazooka import exceptions as exc
+from bazooka import request_id as request_id_ctx
 
 
 def retry_on_network_failure(error):
@@ -45,6 +46,13 @@ class ReliableSession(sessions.Session):
     @log_duration.setter
     def log_duration(self, flag):
         self._log_duration = flag
+
+    def _resolve_headers(self, headers=None):
+        resolved_headers = dict(headers or {})
+        request_id = request_id_ctx.get_request_id()
+        if request_id:
+            resolved_headers.setdefault(request_id_ctx.REQUEST_ID_HEADER, request_id)
+        return resolved_headers
 
     def _log_response(self, response, request_time=None):
         """Default handler for response logging.
@@ -93,7 +101,7 @@ class ReliableSession(sessions.Session):
             url=url,
             params=params,
             data=data,
-            headers=headers,
+            headers=self._resolve_headers(headers),
             cookies=cookies,
             files=files,
             auth=auth,

--- a/bazooka/sessions.py
+++ b/bazooka/sessions.py
@@ -48,7 +48,8 @@ class ReliableSession(sessions.Session):
     def log_duration(self, flag):
         self._log_duration = flag
 
-    def _resolve_headers(self, headers=None):
+    @staticmethod
+    def _resolve_headers(headers=None):
         request_id = request_id_ctx.get_request_id()
         if not request_id:
             return headers

--- a/bazooka/sessions.py
+++ b/bazooka/sessions.py
@@ -49,10 +49,11 @@ class ReliableSession(sessions.Session):
         self._log_duration = flag
 
     def _resolve_headers(self, headers=None):
-        resolved_headers = CaseInsensitiveDict(headers or {})
         request_id = request_id_ctx.get_request_id()
-        if request_id:
-            resolved_headers.setdefault(request_id_ctx.REQUEST_ID_HEADER, request_id)
+        if not request_id:
+            return headers
+        resolved_headers = CaseInsensitiveDict(headers or {})
+        resolved_headers.setdefault(request_id_ctx.REQUEST_ID_HEADER, request_id)
         return resolved_headers
 
     def _log_response(self, response, request_time=None):

--- a/bazooka/sessions.py
+++ b/bazooka/sessions.py
@@ -20,6 +20,7 @@ import time
 import yretry
 from requests import exceptions
 from requests import sessions
+from requests.structures import CaseInsensitiveDict
 
 from bazooka import exceptions as exc
 from bazooka import request_id as request_id_ctx
@@ -48,7 +49,7 @@ class ReliableSession(sessions.Session):
         self._log_duration = flag
 
     def _resolve_headers(self, headers=None):
-        resolved_headers = dict(headers or {})
+        resolved_headers = CaseInsensitiveDict(headers or {})
         request_id = request_id_ctx.get_request_id()
         if request_id:
             resolved_headers.setdefault(request_id_ctx.REQUEST_ID_HEADER, request_id)

--- a/bazooka/tests/test_sessions.py
+++ b/bazooka/tests/test_sessions.py
@@ -208,6 +208,25 @@ class ReliableSessionTestCase(base.IsolatedClassTestCase):
             json=None,
         )
 
+    def test_lowercase_explicit_request_id_has_priority_over_context(self):
+        response = mock.MagicMock()
+        token = request_id_ctx.set_request_id("ctx-rid")
+        try:
+            with mock.patch.object(
+                self.BaseSession, "request", return_value=response
+            ) as request_mock:
+                self.session.request(
+                    "get",
+                    "http://test.local",
+                    headers={"x-request-id": "explicit-rid"},
+                )
+        finally:
+            request_id_ctx.reset_request_id(token)
+
+        call_headers = request_mock.call_args[1]["headers"]
+        self.assertEqual(call_headers.get("X-Request-ID"), "explicit-rid")
+        self.assertEqual(len(call_headers), 1)
+
     def test_request_calls_log_response_without_request_time(self):
         """Check that request method calls _log_response.
 

--- a/bazooka/tests/test_sessions.py
+++ b/bazooka/tests/test_sessions.py
@@ -19,6 +19,7 @@ import mock
 from six import moves
 
 from bazooka.tests import base
+from bazooka import request_id as request_id_ctx
 
 
 def fake_retry(*args, **kwargs):
@@ -63,7 +64,7 @@ class ReliableSessionTestCase(base.IsolatedClassTestCase):
         url = mock.Mock()
         params = mock.Mock()
         data = mock.Mock()
-        headers = mock.Mock()
+        headers = {"X-Test": "1"}
         cookies = mock.Mock()
         files = mock.Mock()
         auth = mock.Mock()
@@ -135,6 +136,77 @@ class ReliableSessionTestCase(base.IsolatedClassTestCase):
             self.session.request(method, url)
 
             response.raise_for_status.assert_called_once_with()
+
+    def test_request_id_from_context_is_added(self):
+        response = mock.MagicMock()
+        token = request_id_ctx.set_request_id("ctx-rid")
+        try:
+            with mock.patch.object(
+                self.BaseSession, "request", return_value=response
+            ) as request_mock:
+                self.session.request(
+                    "get",
+                    "http://test.local",
+                    headers={"Authorization": "Bearer token"},
+                )
+        finally:
+            request_id_ctx.reset_request_id(token)
+
+        request_mock.assert_called_once_with(
+            method="get",
+            url="http://test.local",
+            params=None,
+            data=None,
+            headers={
+                "Authorization": "Bearer token",
+                "X-Request-ID": "ctx-rid",
+            },
+            cookies=None,
+            files=None,
+            auth=None,
+            timeout=None,
+            allow_redirects=True,
+            proxies=None,
+            hooks=None,
+            stream=None,
+            verify=None,
+            cert=None,
+            json=None,
+        )
+
+    def test_explicit_request_id_has_priority_over_context(self):
+        response = mock.MagicMock()
+        token = request_id_ctx.set_request_id("ctx-rid")
+        try:
+            with mock.patch.object(
+                self.BaseSession, "request", return_value=response
+            ) as request_mock:
+                self.session.request(
+                    "get",
+                    "http://test.local",
+                    headers={"X-Request-ID": "explicit-rid"},
+                )
+        finally:
+            request_id_ctx.reset_request_id(token)
+
+        request_mock.assert_called_once_with(
+            method="get",
+            url="http://test.local",
+            params=None,
+            data=None,
+            headers={"X-Request-ID": "explicit-rid"},
+            cookies=None,
+            files=None,
+            auth=None,
+            timeout=None,
+            allow_redirects=True,
+            proxies=None,
+            hooks=None,
+            stream=None,
+            verify=None,
+            cert=None,
+            json=None,
+        )
 
     def test_request_calls_log_response_without_request_time(self):
         """Check that request method calls _log_response.


### PR DESCRIPTION
Introduce request_id contextvar helpers and merge X-Request-ID into ReliableSession outgoing headers when a value is set; preserve an explicit caller header via setdefault. Export request_id from the package API and cover behavior in session tests.